### PR TITLE
Add anew smelting item component

### DIFF
--- a/BP/scripts/anew/items/smelting.js
+++ b/BP/scripts/anew/items/smelting.js
@@ -1,0 +1,74 @@
+import { ItemStack } from "@minecraft/server";
+
+const ORE_PREFIXES = [
+    "deepslate_",
+    "nether_",
+    "end_"
+];
+
+const EXCEPTIONS = {
+    "minecraft:ancient_debris": "minecraft:netherite_scrap",
+    "minecraft:cobblestone": "minecraft:stone",
+    "minecraft:cobbled_deepslate": "minecraft:deepslate"
+};
+
+function normalizeOreName(name) {
+    for (const prefix of ORE_PREFIXES) {
+        if (name.startsWith(prefix)) {
+            return name.slice(prefix.length);
+        }
+    }
+
+    return name;
+}
+
+function getSmeltedId(rawId) {
+    const exception = EXCEPTIONS[rawId];
+    if (exception) return exception;
+
+    if (!rawId.includes(":")) return;
+
+    const [namespace, name] = rawId.split(":");
+
+    if (name.startsWith("raw_") && !name.includes("block")) {
+        return `${namespace}:${name.replace(/^raw_/, "")}_ingot`;
+    }
+
+    if (name.startsWith("raw_") && name.endsWith("_block")) {
+        return `${namespace}:${name.replace(/^raw_/, "")}`;
+    }
+
+    if (name.endsWith("_ore")) {
+        let base = name.slice(0, -4);
+        base = normalizeOreName(base);
+        return `${namespace}:${base}_ingot`;
+    }
+}
+
+DoriosAPI.register.itemComponent("smelting", {
+    onMineBlock({ block, minedBlockPermutation }) {
+        const smeltId = getSmeltedId(minedBlockPermutation.type.id);
+        if (!smeltId) return;
+
+        const { x, y, z } = block.location;
+        const center = { x: x + 0.5, y: y + 0.2, z: z + 0.5 };
+
+        const drops = block.dimension.getEntities({
+            type: "item",
+            maxDistance: 2,
+            location: center
+        });
+
+        for (const entity of drops) {
+            const itemComp = entity.getComponent("minecraft:item");
+            const stack = itemComp?.itemStack;
+            if (!stack) continue;
+
+            if (getSmeltedId(stack.typeId) !== smeltId) continue;
+
+            const amount = stack.amount;
+            entity.remove();
+            block.dimension.spawnItem(new ItemStack(smeltId, amount), center);
+        }
+    }
+});

--- a/BP/scripts/anew/main.js
+++ b/BP/scripts/anew/main.js
@@ -10,4 +10,5 @@ import './items/durability.js'
 import './items/drill.js'
 import './items/block_loot.js'
 import './items/hammer.js'
+import './items/smelting.js'
 


### PR DESCRIPTION
## Summary
- add a DoriosAPI smelting item component that converts mined ore drops to their smelted counterparts
- import the new smelting component from the anew script entrypoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7696f592083309ddb95cff12975ca