### PR TITLE
Refactor antidote potion component registration

### DIFF
--- a/BP/items/utility_items/antidote_potion.json
+++ b/BP/items/utility_items/antidote_potion.json
@@ -1,5 +1,5 @@
 {
-	"format_version": "1.21.10",
+        "format_version": "1.21.90",
 	"minecraft:item": {
 		"description": {
 			"identifier": "utilitycraft:antidote_potion",
@@ -20,9 +20,7 @@
 				"use_duration": 1.5
 			},
 			"minecraft:use_animation": "drink",
-			"minecraft:custom_components": [
-				"utilitycraft:potion"
-			]
-		}
-	}
+                        "utilitycraft:potion": {}
+                }
+        }
 }

--- a/BP/scripts/anew/main.js
+++ b/BP/scripts/anew/main.js
@@ -11,4 +11,5 @@ import './items/drill.js'
 import './items/block_loot.js'
 import './items/hammer.js'
 import './items/smelting.js'
+import '../items/tools/potion.js'
 

--- a/BP/scripts/items/tools/potion.js
+++ b/BP/scripts/items/tools/potion.js
@@ -1,16 +1,13 @@
-import { world } from '@minecraft/server'
-
-world.beforeEvents.worldInitialize.subscribe(eventData => {
-    eventData.itemComponentRegistry.registerCustomComponent('utilitycraft:potion', {
-        onUse(e) {
-            const { source } = e
-            let entity = undefined
-            if (source.getEntitiesFromViewDirection()[0] != undefined) {
-                entity = source.getEntitiesFromViewDirection({ maxDistance: 3 })[0].entity
-                if (entity.typeId == 'minecraft:zombie_villager_v2') {
-                    entity.triggerEvent('villager_converted')
-                }
-            }
+DoriosAPI.register.itemComponent("potion", {
+    /**
+     * Handles the potion's use interaction.
+     *
+     * @param {import("@minecraft/server").ItemComponentUseEvent} event
+     */
+    onUse({ source }) {
+        const target = source.getEntitiesFromViewDirection({ maxDistance: 3 })?.[0]?.entity;
+        if (target?.typeId === "minecraft:zombie_villager_v2") {
+            target.triggerEvent("villager_converted");
         }
-    })
-})
+    }
+});


### PR DESCRIPTION
## Summary
- register the potion custom component through the DoriosAPI helper to match the new item architecture
- ensure the anew script entry point loads the potion component handler
- update the antidote potion item definition to format 1.21.90 and use the new custom component syntax

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7701edde48330870f86f90eb10ea7