### PR TITLE
Attach dig pebble component to hammer items

### DIFF
--- a/BP/items/tools/hammers/diamond_hammer.json
+++ b/BP/items/tools/hammers/diamond_hammer.json
@@ -8,6 +8,7 @@
 			"utilitycraft:hammer": {
 				"tier": 3
 			},
+			"utilitycraft:dig_pebble": {},
 			"minecraft:max_stack_size": 1,
 			"minecraft:tags": {
 				"tags": [

--- a/BP/items/tools/hammers/iron_hammer.json
+++ b/BP/items/tools/hammers/iron_hammer.json
@@ -8,6 +8,7 @@
 			"utilitycraft:hammer": {
 				"tier": 2
 			},
+			"utilitycraft:dig_pebble": {},
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/hammers/netherite_hammer.json
+++ b/BP/items/tools/hammers/netherite_hammer.json
@@ -8,6 +8,7 @@
 			"utilitycraft:hammer": {
 				"tier": 3
 			},
+			"utilitycraft:dig_pebble": {},
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/hammers/stone_hammer.json
+++ b/BP/items/tools/hammers/stone_hammer.json
@@ -8,6 +8,7 @@
 			"utilitycraft:hammer": {
 				"tier": 1
 			},
+			"utilitycraft:dig_pebble": {},
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/hammers/wooden_hammer.json
+++ b/BP/items/tools/hammers/wooden_hammer.json
@@ -8,6 +8,7 @@
 			"utilitycraft:hammer": {
 				"tier": 0
 			},
+			"utilitycraft:dig_pebble": {},
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/scripts/anew/items/dig_pebble.js
+++ b/BP/scripts/anew/items/dig_pebble.js
@@ -1,0 +1,56 @@
+import { ItemStack, ItemEnchantableComponent } from "@minecraft/server";
+
+const digDrops = [
+    { drop: "utilitycraft:gravel_fragments", min: 1, max: 2, prob: 50 },
+    { drop: "utilitycraft:stone_pebble", min: 1, max: 2, prob: 50 },
+    { drop: "utilitycraft:dirt_handful", min: 1, max: 1, prob: 20 },
+    { drop: "utilitycraft:andesite_pebble", min: 1, max: 1, prob: 20 },
+    { drop: "utilitycraft:diorite_pebble", min: 1, max: 1, prob: 20 },
+    { drop: "utilitycraft:granite_pebble", min: 1, max: 1, prob: 20 },
+    { drop: "minecraft:bone_meal", min: 1, max: 1, prob: 10 }
+];
+
+DoriosAPI.register.itemComponent("dig_pebble", {
+    onUseOn({ block, source, itemStack }) {
+        if (!source?.isSneaking) return;
+        if (!block) return;
+
+        const blockId = block.typeId;
+        if (blockId !== "minecraft:dirt" && blockId !== "minecraft:grass_block") return;
+
+        const location = {
+            x: block.location.x + 0.5,
+            y: block.location.y + 1,
+            z: block.location.z + 0.5
+        };
+
+        for (const drop of digDrops) {
+            if (Math.random() * 100 > drop.prob) continue;
+
+            const amount = DoriosAPI.utils.randomInterval(drop.min, drop.max);
+            block.dimension.spawnItem(new ItemStack(drop.drop, amount), location);
+        }
+
+        if (source.matches?.({ gameMode: "creative" })) return;
+
+        const durability = itemStack.getComponent("minecraft:durability");
+        if (!durability) return;
+
+        const inventory = source.getComponent("minecraft:inventory")?.container;
+        const ench = itemStack.getComponent(ItemEnchantableComponent.componentId);
+        const unbreaking = ench?.getEnchantment?.("unbreaking")?.level ?? 0;
+
+        const shouldDamage = Math.ceil(Math.random() * 100) <= (100 / (unbreaking + 1));
+        if (!shouldDamage) return;
+
+        if (durability.damage + 1 <= durability.maxDurability) {
+            durability.damage += 1;
+            inventory?.setItem(source.selectedSlotIndex, itemStack);
+            return;
+        }
+
+        inventory?.setItem(source.selectedSlotIndex, undefined);
+        source.playSound?.("random.break");
+    }
+});
+

--- a/BP/scripts/anew/main.js
+++ b/BP/scripts/anew/main.js
@@ -10,6 +10,7 @@ import './items/durability.js'
 import './items/drill.js'
 import './items/block_loot.js'
 import './items/hammer.js'
+import './items/dig_pebble.js'
 import './items/smelting.js'
 import './items/potion.js'
 

--- a/BP/scripts/others/digPebbles.js
+++ b/BP/scripts/others/digPebbles.js
@@ -1,4 +1,5 @@
 import { world, ItemStack, ItemEnchantableComponent } from '@minecraft/server'
+import * as DoriosAPI from '../doriosAPI.js'
 
 const digDrops = [
     { drop: 'utilitycraft:gravel_fragments', min: 1, max: 2, prob: 50 },
@@ -15,7 +16,7 @@ function itemDrops(drop, block) {
     let { x, y, z } = block.location
     x += 0.5; y += 1; z += 0.5
     if (roll <= drop.prob) {
-        let numDrops = Math.floor(Math.random() * (drop.max - drop.min + 1)) + drop.min;
+        const numDrops = DoriosAPI.utils.randomInterval(drop.min, drop.max)
         block.dimension.spawnItem(new ItemStack(drop.drop, numDrops), { x, y, z })
     }
 }
@@ -34,8 +35,8 @@ world.beforeEvents.worldInitialize.subscribe(e => {
             const inventory = source.getComponent("minecraft:inventory").container
             const ench = itemStack.getComponent(ItemEnchantableComponent.componentId)
             let unbreaking = 0
-            if (ench == undefined) {
-                unbreaking = ench.getEnchantment("unbreaking").level
+            if (ench !== undefined) {
+                unbreaking = ench.getEnchantment("unbreaking")?.level ?? 0
             }
             if (!source.matches({ gameMode: 'creative' })) {
                 if ((Math.ceil(Math.random() * 100)) <= (100 / (unbreaking + 1))) {


### PR DESCRIPTION
## Summary
- add the `utilitycraft:dig_pebble` custom component to every hammer item definition so they trigger the new behaviour
- guard the legacy dig pebble component's unbreaking lookup to avoid dereferencing an undefined enchant component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d77bd487348330bab8d6435604b05b