### PR TITLE
Remove custom break component from tools

### DIFF
--- a/BP/items/tools/paxels/diamond_paxel.json
+++ b/BP/items/tools/paxels/diamond_paxel.json
@@ -17,9 +17,6 @@
 			"minecraft:durability": {
 				"max_durability": 4683
 			},
-			"minecraft:custom_components": [
-				"utilitycraft:break"
-			],
 			"minecraft:damage": 6,
 			"minecraft:icon": "utilitycraft_diamond_paxel",
 			"minecraft:enchantable": {

--- a/BP/items/tools/paxels/gold_paxel.json
+++ b/BP/items/tools/paxels/gold_paxel.json
@@ -16,9 +16,6 @@
 			"minecraft:durability": {
 				"max_durability": 144
 			},
-			"minecraft:custom_components": [
-				"utilitycraft:break"
-			],
 			"minecraft:damage": 4,
 			"minecraft:icon": "utilitycraft_gold_paxel",
 			"minecraft:enchantable": {

--- a/BP/items/tools/paxels/iron_paxel.json
+++ b/BP/items/tools/paxels/iron_paxel.json
@@ -16,9 +16,6 @@
 			"minecraft:durability": {
 				"max_durability": 753
 			},
-			"minecraft:custom_components": [
-				"utilitycraft:break"
-			],
 			"minecraft:damage": 5,
 			"minecraft:icon": "utilitycraft_iron_paxel",
 			"minecraft:enchantable": {

--- a/BP/items/tools/paxels/netherite_paxel.json
+++ b/BP/items/tools/paxels/netherite_paxel.json
@@ -19,9 +19,6 @@
 			"minecraft:durability": {
 				"max_durability": 6093
 			},
-			"minecraft:custom_components": [
-				"utilitycraft:break"
-			],
 			"minecraft:damage": 7,
 			"minecraft:icon": "utilitycraft_netherite_paxel",
 			"minecraft:enchantable": {

--- a/BP/items/tools/paxels/stone_paxel.json
+++ b/BP/items/tools/paxels/stone_paxel.json
@@ -16,9 +16,6 @@
 			"minecraft:durability": {
 				"max_durability": 249
 			},
-			"minecraft:custom_components": [
-				"utilitycraft:break"
-			],
 			"minecraft:damage": 5,
 			"minecraft:icon": "utilitycraft_stone_paxel",
 			"minecraft:enchantable": {

--- a/BP/items/tools/paxels/wood_paxel.json
+++ b/BP/items/tools/paxels/wood_paxel.json
@@ -16,9 +16,6 @@
 			"minecraft:durability": {
 				"max_durability": 180
 			},
-			"minecraft:custom_components": [
-				"utilitycraft:break"
-			],
 			"minecraft:damage": 6,
 			"minecraft:icon": "utilitycraft_wood_paxel",
 			"minecraft:enchantable": {

--- a/BP/items/tools/special/lucky_pickaxe.json
+++ b/BP/items/tools/special/lucky_pickaxe.json
@@ -14,9 +14,6 @@
 				"value": 15,
 				"slot": "pickaxe"
 			},
-			"minecraft:custom_components": [
-				"utilitycraft:break"
-			],
 			"minecraft:repairable": {
 				"repair_items": [
 					{

--- a/BP/items/tools/special/lucky_sword.json
+++ b/BP/items/tools/special/lucky_sword.json
@@ -14,9 +14,6 @@
 				"max_durability": 1125
 			},
 			"minecraft:damage": 8,
-			"minecraft:custom_components": [
-				"utilitycraft:break"
-			],
 			"minecraft:digger": {
 				"use_efficiency": true,
 				"destroy_speeds": [


### PR DESCRIPTION
## Summary
- remove the `minecraft:custom_components` entry referencing `utilitycraft:break` from each custom tool item definition

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df516951d0833088fd75ad7edc1598