### PR TITLE
Add UI element tags to lava bar items

### DIFF
--- a/BP/items/ui/lava_bar/utilitycraft_lava_00.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_00.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_00"
+            "minecraft:icon": "utilitycraft:lava_00",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_01.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_01.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_01"
+            "minecraft:icon": "utilitycraft:lava_01",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_02.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_02.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_02"
+            "minecraft:icon": "utilitycraft:lava_02",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_03.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_03.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_03"
+            "minecraft:icon": "utilitycraft:lava_03",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_04.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_04.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_04"
+            "minecraft:icon": "utilitycraft:lava_04",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_05.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_05.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_05"
+            "minecraft:icon": "utilitycraft:lava_05",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_06.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_06.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_06"
+            "minecraft:icon": "utilitycraft:lava_06",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_07.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_07.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_07"
+            "minecraft:icon": "utilitycraft:lava_07",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_08.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_08.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_08"
+            "minecraft:icon": "utilitycraft:lava_08",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_09.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_09.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_09"
+            "minecraft:icon": "utilitycraft:lava_09",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_10.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_10.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_10"
+            "minecraft:icon": "utilitycraft:lava_10",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_11.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_11.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_11"
+            "minecraft:icon": "utilitycraft:lava_11",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_12.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_12.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_12"
+            "minecraft:icon": "utilitycraft:lava_12",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_13.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_13.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_13"
+            "minecraft:icon": "utilitycraft:lava_13",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_14.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_14.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_14"
+            "minecraft:icon": "utilitycraft:lava_14",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_15.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_15.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_15"
+            "minecraft:icon": "utilitycraft:lava_15",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_16.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_16.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_16"
+            "minecraft:icon": "utilitycraft:lava_16",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_17.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_17.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_17"
+            "minecraft:icon": "utilitycraft:lava_17",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_18.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_18.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_18"
+            "minecraft:icon": "utilitycraft:lava_18",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_19.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_19.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_19"
+            "minecraft:icon": "utilitycraft:lava_19",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_20.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_20.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_20"
+            "minecraft:icon": "utilitycraft:lava_20",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_21.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_21.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_21"
+            "minecraft:icon": "utilitycraft:lava_21",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_22.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_22.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_22"
+            "minecraft:icon": "utilitycraft:lava_22",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_23.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_23.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_23"
+            "minecraft:icon": "utilitycraft:lava_23",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_24.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_24.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_24"
+            "minecraft:icon": "utilitycraft:lava_24",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_25.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_25.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_25"
+            "minecraft:icon": "utilitycraft:lava_25",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_26.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_26.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_26"
+            "minecraft:icon": "utilitycraft:lava_26",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_27.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_27.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_27"
+            "minecraft:icon": "utilitycraft:lava_27",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_28.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_28.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_28"
+            "minecraft:icon": "utilitycraft:lava_28",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_29.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_29.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_29"
+            "minecraft:icon": "utilitycraft:lava_29",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_30.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_30.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_30"
+            "minecraft:icon": "utilitycraft:lava_30",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_31.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_31.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_31"
+            "minecraft:icon": "utilitycraft:lava_31",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_32.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_32.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_32"
+            "minecraft:icon": "utilitycraft:lava_32",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_33.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_33.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_33"
+            "minecraft:icon": "utilitycraft:lava_33",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_34.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_34.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_34"
+            "minecraft:icon": "utilitycraft:lava_34",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_35.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_35.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_35"
+            "minecraft:icon": "utilitycraft:lava_35",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_36.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_36.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_36"
+            "minecraft:icon": "utilitycraft:lava_36",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_37.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_37.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_37"
+            "minecraft:icon": "utilitycraft:lava_37",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_38.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_38.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_38"
+            "minecraft:icon": "utilitycraft:lava_38",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_39.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_39.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_39"
+            "minecraft:icon": "utilitycraft:lava_39",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_40.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_40.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_40"
+            "minecraft:icon": "utilitycraft:lava_40",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_41.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_41.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_41"
+            "minecraft:icon": "utilitycraft:lava_41",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_42.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_42.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_42"
+            "minecraft:icon": "utilitycraft:lava_42",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_43.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_43.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_43"
+            "minecraft:icon": "utilitycraft:lava_43",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_44.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_44.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_44"
+            "minecraft:icon": "utilitycraft:lava_44",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_45.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_45.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_45"
+            "minecraft:icon": "utilitycraft:lava_45",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_46.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_46.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_46"
+            "minecraft:icon": "utilitycraft:lava_46",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_47.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_47.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_47"
+            "minecraft:icon": "utilitycraft:lava_47",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }

--- a/BP/items/ui/lava_bar/utilitycraft_lava_48.json
+++ b/BP/items/ui/lava_bar/utilitycraft_lava_48.json
@@ -8,7 +8,12 @@
             }
         },
         "components": {
-            "minecraft:icon": "utilitycraft:lava_48"
+            "minecraft:icon": "utilitycraft:lava_48",
+            "minecraft:tags": {
+                "tags": [
+                    "utilitycraft:ui_element"
+                ]
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add the utilitycraft:ui_element tag to all lava bar UI items so they are recognized as UI elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eaf95187088330aa5c0a261c4fd871