### PR TITLE
Add material tiers to UtilityCraft tools

### DIFF
--- a/BP/items/tools/AIOTs/copper_aiot.json
+++ b/BP/items/tools/AIOTs/copper_aiot.json
@@ -13,8 +13,9 @@
 				"tags": [
 					"minecraft:is_axe",
 					"minecraft:is_pickaxe",
-					"minecraft:is_sword",
-					"utilitycraft:is_aiot"
+                                        "minecraft:is_sword",
+                                        "utilitycraft:is_aiot",
+                                        "minecraft:copper_tier"
 				]
 			},
 			"minecraft:icon": "utilitycraft_copper_aiot",

--- a/BP/items/tools/AIOTs/diamond_aiot.json
+++ b/BP/items/tools/AIOTs/diamond_aiot.json
@@ -14,8 +14,9 @@
 					"minecraft:is_axe",
 					"minecraft:is_pickaxe",
 					"minecraft:is_sword",
-					"utilitycraft:is_aiot",
-					"minecraft:transformable_items"
+                                        "utilitycraft:is_aiot",
+                                        "minecraft:transformable_items",
+                                        "minecraft:diamond_tier"
 				]
 			},
 			"minecraft:icon": "utilitycraft_diamond_aiot",

--- a/BP/items/tools/AIOTs/iron_aiot.json
+++ b/BP/items/tools/AIOTs/iron_aiot.json
@@ -13,8 +13,9 @@
 				"tags": [
 					"minecraft:is_axe",
 					"minecraft:is_pickaxe",
-					"minecraft:is_sword",
-					"utilitycraft:is_aiot"
+                                        "minecraft:is_sword",
+                                        "utilitycraft:is_aiot",
+                                        "minecraft:iron_tier"
 				]
 			},
 			"minecraft:icon": "utilitycraft_iron_aiot",

--- a/BP/items/tools/AIOTs/netherite_aiot.json
+++ b/BP/items/tools/AIOTs/netherite_aiot.json
@@ -13,8 +13,9 @@
 				"tags": [
 					"minecraft:is_axe",
 					"minecraft:is_pickaxe",
-					"minecraft:is_sword",
-					"utilitycraft:is_aiot"
+                                        "minecraft:is_sword",
+                                        "utilitycraft:is_aiot",
+                                        "minecraft:netherite_tier"
 				]
 			},
 			"minecraft:fire_resistant": {

--- a/BP/items/tools/AIOTs/steel_aiot.json
+++ b/BP/items/tools/AIOTs/steel_aiot.json
@@ -13,8 +13,9 @@
 				"tags": [
 					"minecraft:is_axe",
 					"minecraft:is_pickaxe",
-					"minecraft:is_sword",
-					"utilitycraft:is_aiot"
+                                        "minecraft:is_sword",
+                                        "utilitycraft:is_aiot",
+                                        "minecraft:iron_tier"
 				]
 			},
 			"minecraft:icon": "utilitycraft_steel_aiot",

--- a/BP/items/tools/AIOTs/stone_aiot.json
+++ b/BP/items/tools/AIOTs/stone_aiot.json
@@ -13,8 +13,9 @@
 				"tags": [
 					"minecraft:is_axe",
 					"minecraft:is_pickaxe",
-					"minecraft:is_sword",
-					"utilitycraft:is_aiot"
+                                        "minecraft:is_sword",
+                                        "utilitycraft:is_aiot",
+                                        "minecraft:stone_tier"
 				]
 			},
 			"minecraft:icon": "utilitycraft_stone_aiot",

--- a/BP/items/tools/drills/drill.json
+++ b/BP/items/tools/drills/drill.json
@@ -7,8 +7,13 @@
 				"category": "equipment"
 			}
 		},
-		"components": {
-			"utilitycraft:drill": {},
+                "components": {
+                        "utilitycraft:drill": {},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:iron_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/drills/heavy_drill.json
+++ b/BP/items/tools/drills/heavy_drill.json
@@ -7,10 +7,15 @@
 				"category": "equipment"
 			}
 		},
-		"components": {
-			"utilitycraft:drill": {
-				"size": 5
-			},
+                "components": {
+                        "utilitycraft:drill": {
+                                "size": 5
+                        },
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:diamond_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/hammers/copper_hammer.json
+++ b/BP/items/tools/hammers/copper_hammer.json
@@ -8,7 +8,12 @@
 			"utilitycraft:hammer": {
 				"tier": 1
 			},
-			"utilitycraft:dig_pebble": {},
+                        "utilitycraft:dig_pebble": {},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:copper_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/hammers/diamond_hammer.json
+++ b/BP/items/tools/hammers/diamond_hammer.json
@@ -8,7 +8,12 @@
 			"utilitycraft:hammer": {
 				"tier": 3
 			},
-			"utilitycraft:dig_pebble": {},
+                        "utilitycraft:dig_pebble": {},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:diamond_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:tags": {
 				"tags": [

--- a/BP/items/tools/hammers/iron_hammer.json
+++ b/BP/items/tools/hammers/iron_hammer.json
@@ -8,7 +8,12 @@
 			"utilitycraft:hammer": {
 				"tier": 2
 			},
-			"utilitycraft:dig_pebble": {},
+                        "utilitycraft:dig_pebble": {},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:iron_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/hammers/netherite_hammer.json
+++ b/BP/items/tools/hammers/netherite_hammer.json
@@ -8,7 +8,12 @@
 			"utilitycraft:hammer": {
 				"tier": 3
 			},
-			"utilitycraft:dig_pebble": {},
+                        "utilitycraft:dig_pebble": {},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:netherite_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/hammers/steel_hammer.json
+++ b/BP/items/tools/hammers/steel_hammer.json
@@ -8,7 +8,12 @@
 			"utilitycraft:hammer": {
 				"tier": 2
 			},
-			"utilitycraft:dig_pebble": {},
+                        "utilitycraft:dig_pebble": {},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:iron_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/hammers/stone_hammer.json
+++ b/BP/items/tools/hammers/stone_hammer.json
@@ -8,7 +8,12 @@
 			"utilitycraft:hammer": {
 				"tier": 1
 			},
-			"utilitycraft:dig_pebble": {},
+                        "utilitycraft:dig_pebble": {},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:stone_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/paxels/copper_paxel.json
+++ b/BP/items/tools/paxels/copper_paxel.json
@@ -5,12 +5,13 @@
 			"identifier": "utilitycraft:copper_paxel"
 		},
 		"components": {
-			"minecraft:tags": {
-				"tags": [
-					"minecraft:is_axe",
-					"minecraft:is_pickaxe"
-				]
-			},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:is_axe",
+                                        "minecraft:is_pickaxe",
+                                        "minecraft:copper_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/paxels/diamond_paxel.json
+++ b/BP/items/tools/paxels/diamond_paxel.json
@@ -8,8 +8,9 @@
 			"minecraft:tags": {
 				"tags": [
 					"minecraft:is_axe",
-					"minecraft:is_pickaxe",
-					"minecraft:transformable_items"
+                                        "minecraft:is_pickaxe",
+                                        "minecraft:transformable_items",
+                                        "minecraft:diamond_tier"
 				]
 			},
 			"minecraft:max_stack_size": 1,

--- a/BP/items/tools/paxels/iron_paxel.json
+++ b/BP/items/tools/paxels/iron_paxel.json
@@ -5,12 +5,13 @@
 			"identifier": "utilitycraft:iron_paxel"
 		},
 		"components": {
-			"minecraft:tags": {
-				"tags": [
-					"minecraft:is_axe",
-					"minecraft:is_pickaxe"
-				]
-			},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:is_axe",
+                                        "minecraft:is_pickaxe",
+                                        "minecraft:iron_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/paxels/netherite_paxel.json
+++ b/BP/items/tools/paxels/netherite_paxel.json
@@ -5,12 +5,13 @@
 			"identifier": "utilitycraft:netherite_paxel"
 		},
 		"components": {
-			"minecraft:tags": {
-				"tags": [
-					"minecraft:is_axe",
-					"minecraft:is_pickaxe"
-				]
-			},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:is_axe",
+                                        "minecraft:is_pickaxe",
+                                        "minecraft:netherite_tier"
+                                ]
+                        },
 			"minecraft:fire_resistant": {
 				"value": true
 			},

--- a/BP/items/tools/paxels/steel_paxel.json
+++ b/BP/items/tools/paxels/steel_paxel.json
@@ -5,12 +5,13 @@
 			"identifier": "utilitycraft:steel_paxel"
 		},
 		"components": {
-			"minecraft:tags": {
-				"tags": [
-					"minecraft:is_axe",
-					"minecraft:is_pickaxe"
-				]
-			},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:is_axe",
+                                        "minecraft:is_pickaxe",
+                                        "minecraft:iron_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/paxels/stone_paxel.json
+++ b/BP/items/tools/paxels/stone_paxel.json
@@ -5,12 +5,13 @@
 			"identifier": "utilitycraft:stone_paxel"
 		},
 		"components": {
-			"minecraft:tags": {
-				"tags": [
-					"minecraft:is_axe",
-					"minecraft:is_pickaxe"
-				]
-			},
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:is_axe",
+                                        "minecraft:is_pickaxe",
+                                        "minecraft:stone_tier"
+                                ]
+                        },
 			"minecraft:max_stack_size": 1,
 			"minecraft:hand_equipped": true,
 			"minecraft:durability": {

--- a/BP/items/tools/special/lucky_pickaxe.json
+++ b/BP/items/tools/special/lucky_pickaxe.json
@@ -9,7 +9,12 @@
 			}
 		},
 		"components": {
-			"minecraft:icon": "utilitycraft_lucky_pickaxe",
+                        "minecraft:icon": "utilitycraft_lucky_pickaxe",
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:diamond_tier"
+                                ]
+                        },
 			"minecraft:enchantable": {
 				"value": 15,
 				"slot": "pickaxe"

--- a/BP/items/tools/special/lucky_pickaxe_item.json
+++ b/BP/items/tools/special/lucky_pickaxe_item.json
@@ -8,12 +8,17 @@
 				"group": "itemGroup.name.pickaxe"
 			}
 		},
-		"components": {
-			"minecraft:icon": "utilitycraft_lucky_pickaxe_item",
-			"minecraft:glint": true,
-			"minecraft:max_stack_size": 1,
-			"minecraft:hand_equipped": true,
-			"minecraft:damage": 6
-		}
+                "components": {
+                        "minecraft:icon": "utilitycraft_lucky_pickaxe_item",
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:diamond_tier"
+                                ]
+                        },
+                        "minecraft:glint": true,
+                        "minecraft:max_stack_size": 1,
+                        "minecraft:hand_equipped": true,
+                        "minecraft:damage": 6
+                }
 	}
 }

--- a/BP/items/tools/special/smelting_pickaxe.json
+++ b/BP/items/tools/special/smelting_pickaxe.json
@@ -14,8 +14,13 @@
 			"minecraft:durability": {
 				"max_durability": 3031
 			},
-			"minecraft:damage": 7,
-			"minecraft:icon": "utilitycraft_smelting_pickaxe",
+                        "minecraft:damage": 7,
+                        "minecraft:icon": "utilitycraft_smelting_pickaxe",
+                        "minecraft:tags": {
+                                "tags": [
+                                        "minecraft:netherite_tier"
+                                ]
+                        },
 			"minecraft:enchantable": {
 				"value": 15,
 				"slot": "pickaxe"

--- a/BP/items/tools/steel/steel_axe.json
+++ b/BP/items/tools/steel/steel_axe.json
@@ -10,6 +10,11 @@
         },
         "components": {
             "minecraft:icon": "utilitycraft_steel_axe",
+            "minecraft:tags": {
+                "tags": [
+                    "minecraft:iron_tier"
+                ]
+            },
             "minecraft:max_stack_size": 1,
             "minecraft:hand_equipped": true,
             "minecraft:durability": {

--- a/BP/items/tools/steel/steel_hoe.json
+++ b/BP/items/tools/steel/steel_hoe.json
@@ -10,6 +10,11 @@
         },
         "components": {
             "minecraft:icon": "utilitycraft_steel_hoe",
+            "minecraft:tags": {
+                "tags": [
+                    "minecraft:iron_tier"
+                ]
+            },
             "minecraft:max_stack_size": 1,
             "minecraft:hand_equipped": true,
             "minecraft:durability": {

--- a/BP/items/tools/steel/steel_pickaxe.json
+++ b/BP/items/tools/steel/steel_pickaxe.json
@@ -10,6 +10,11 @@
         },
         "components": {
             "minecraft:icon": "utilitycraft_steel_pickaxe",
+            "minecraft:tags": {
+                "tags": [
+                    "minecraft:iron_tier"
+                ]
+            },
             "minecraft:max_stack_size": 1,
             "minecraft:hand_equipped": true,
             "minecraft:durability": {

--- a/BP/items/tools/steel/steel_shovel.json
+++ b/BP/items/tools/steel/steel_shovel.json
@@ -10,6 +10,11 @@
         },
         "components": {
             "minecraft:icon": "utilitycraft_steel_shovel",
+            "minecraft:tags": {
+                "tags": [
+                    "minecraft:iron_tier"
+                ]
+            },
             "minecraft:max_stack_size": 1,
             "minecraft:hand_equipped": true,
             "minecraft:durability": {

--- a/BP/items/tools/steel/steel_sword.json
+++ b/BP/items/tools/steel/steel_sword.json
@@ -10,6 +10,11 @@
         },
         "components": {
             "minecraft:icon": "utilitycraft_steel_sword",
+            "minecraft:tags": {
+                "tags": [
+                    "minecraft:iron_tier"
+                ]
+            },
             "minecraft:max_stack_size": 1,
             "minecraft:hand_equipped": true,
             "minecraft:durability": {


### PR DESCRIPTION
## Summary
- add Minecraft tier tags to paxels, hammers, AIOTs, and drills based on their material strength
- mark lucky and smelting specialty tools with the correct diamond or netherite tiers
- ensure all steel equipment is tagged as iron tier for compatibility with tier checks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6908269264248330843033c0a54e89a1