### PR TITLE
Improve Insight machine helper compatibility

### DIFF
--- a/BP/scripts/DoriosCore/constants.js
+++ b/BP/scripts/DoriosCore/constants.js
@@ -10,6 +10,12 @@
 export const DEFAULT_ENTITY_ID = "utilitycraft:machine_entity";
 
 /**
+ * Dynamic property used to persist which block a machine helper entity
+ * currently represents.
+ */
+export const MACHINE_BLOCK_ID_PROPERTY_ID = "dorios:machine_block_id";
+
+/**
  * Default machine processing interval.
  *
  * Represents the number of ticks between machine updates.

--- a/BP/scripts/DoriosCore/machinery/energyStorage.js
+++ b/BP/scripts/DoriosCore/machinery/energyStorage.js
@@ -154,7 +154,8 @@ export class EnergyStorage {
     const matches = [...cleanedInput.matchAll(/([\d.]+)\s*(PDE|TDE|GDE|MDE|KDE|DE)/gi)];
 
     if (!matches.length || index < 0 || index >= matches.length) {
-      throw new Error("Invalid input or index: couldn't parse energy values.");
+      return
+      // throw new Error("Invalid input or index: couldn't parse energy values.");
     }
 
     const [, valueStr, rawUnit] = matches[index];

--- a/BP/scripts/DoriosCore/machinery/energyStorage.js
+++ b/BP/scripts/DoriosCore/machinery/energyStorage.js
@@ -111,26 +111,29 @@ export class EnergyStorage {
    * formatEnergyToText(1048576); // "1.05 MDE"
    */
   static formatEnergyToText(value) {
-    let unit = "DE";
+    const safeValue = Math.max(0, Number(value) || 0);
 
-    if (value >= 1e15) {
-      unit = "PDE";
-      value /= 1e15;
-    } else if (value >= 1e12) {
-      unit = "TDE";
-      value /= 1e12;
-    } else if (value >= 1e9) {
-      unit = "GDE";
-      value /= 1e9;
-    } else if (value >= 1e6) {
-      unit = "MDE";
-      value /= 1e6;
-    } else if (value >= 1e3) {
-      unit = "kDE";
-      value /= 1e3;
+    if (safeValue >= 1e15) {
+      return `${(safeValue / 1e15).toFixed(2)} PDE`;
     }
 
-    return `${parseFloat(value.toFixed(2))} ${unit}`;
+    if (safeValue >= 1e12) {
+      return `${(safeValue / 1e12).toFixed(2)} TDE`;
+    }
+
+    if (safeValue >= 1e9) {
+      return `${(safeValue / 1e9).toFixed(2)} GDE`;
+    }
+
+    if (safeValue >= 1e6) {
+      return `${(safeValue / 1e6).toFixed(2)} MDE`;
+    }
+
+    if (safeValue >= 1e3) {
+      return `${(safeValue / 1e3).toFixed(1)} kDE`;
+    }
+
+    return `${Math.floor(safeValue)} DE`;
   }
 
   /**
@@ -148,38 +151,24 @@ export class EnergyStorage {
     // Remove Minecraft formatting codes
     const cleanedInput = input.replace(/§[0-9a-frklmnor]/gi, "");
 
-    // Find all matches like "12.5 kDE"
-    const matches = cleanedInput.match(/([\d.]+)\s*(kDE|MDE|GDE|TDE|DE)/g);
+    const matches = [...cleanedInput.matchAll(/([\d.]+)\s*(PDE|TDE|GDE|MDE|KDE|DE)/gi)];
 
-    if (!matches || index >= matches.length) {
+    if (!matches.length || index < 0 || index >= matches.length) {
       throw new Error("Invalid input or index: couldn't parse energy values.");
     }
 
-    const [valueStr, unit] = matches[index].split(" ");
-    let multiplier = 1;
+    const [, valueStr, rawUnit] = matches[index];
+    const unit = String(rawUnit || "DE").toUpperCase();
+    const multipliers = {
+      DE: 1,
+      KDE: 1e3,
+      MDE: 1e6,
+      GDE: 1e9,
+      TDE: 1e12,
+      PDE: 1e15,
+    };
 
-    switch (unit) {
-      case "kDE":
-        multiplier = 1e3;
-        break;
-      case "MDE":
-        multiplier = 1e6;
-        break;
-      case "GDE":
-        multiplier = 1e9;
-        break;
-      case "TDE":
-        multiplier = 1e12;
-        break;
-      case "PDE":
-        multiplier = 1e15;
-        break;
-      case "DE":
-        multiplier = 1;
-        break;
-    }
-
-    return parseFloat(valueStr) * multiplier;
+    return parseFloat(valueStr) * (multipliers[unit] ?? 1);
   }
   //#endregion
 

--- a/BP/scripts/DoriosCore/machinery/fluidStorage.js
+++ b/BP/scripts/DoriosCore/machinery/fluidStorage.js
@@ -235,24 +235,31 @@ export class FluidStorage {
     const safeValue = Math.max(0, Number(value) || 0);
 
     if (safeValue >= 1e18) {
-      return `${(safeValue / 1e18).toFixed(2)} EB`; } // ExaBucket (EB) for extremely large values
+      return `${(safeValue / 1e18).toFixed(2)} EB`;
+    } // ExaBucket (EB) for extremely large values
 
     if (safeValue >= 1e15) {
-      return `${(safeValue / 1e15).toFixed(2)} PB`; } // PetaBucket (PB) for very large values
+      return `${(safeValue / 1e15).toFixed(2)} PB`;
+    } // PetaBucket (PB) for very large values
 
     if (safeValue >= 1e12) {
-      return `${(safeValue / 1e12).toFixed(2)} TB`; } // TeraBucket (TB) for large values
+      return `${(safeValue / 1e12).toFixed(2)} TB`;
+    } // TeraBucket (TB) for large values
 
     if (safeValue >= 1e9) {
-      return `${(safeValue / 1e9).toFixed(2)} MB`; } // MegaBucket (MB) for large values
+      return `${(safeValue / 1e9).toFixed(2)} MB`;
+    } // MegaBucket (MB) for large values
 
     if (safeValue >= 1e6) {
-      return `${(safeValue / 1e6).toFixed(2)} KB`; } // KiloBucket (KB) for medium values
+      return `${(safeValue / 1e6).toFixed(2)} KB`;
+    } // KiloBucket (KB) for medium values
 
     if (safeValue >= 1e3) {
-      return `${(safeValue / 1e3).toFixed(1)} B`; } // Bucket (B) for small values
+      return `${(safeValue / 1e3).toFixed(1)} B`;
+    } // Bucket (B) for small values
 
-    return `${Math.floor(safeValue)} mB`; } // Milibucket (mB) for very small values
+    return `${Math.floor(safeValue)} mB`;
+  } // Milibucket (mB) for very small values
 
   /**
    * Extracts the fluid type and amount from a formatted text like:

--- a/BP/scripts/DoriosCore/machinery/fluidStorage.js
+++ b/BP/scripts/DoriosCore/machinery/fluidStorage.js
@@ -232,15 +232,33 @@ export class FluidStorage {
    * @returns {string} A formatted string with unit suffix (mB, kB, MB).
    */
   static formatFluid(value) {
-    let unit = "mB";
-    if (value >= 1e7) {
-      unit = "MB";
-      value /= 1e6;
-    } else if (value >= 1e4) {
-      unit = "kB";
-      value /= 1e3;
+    const safeValue = Math.max(0, Number(value) || 0);
+
+    if (safeValue >= 1e18) {
+      return `${(safeValue / 1e18).toFixed(2)} EB`;
     }
-    return `${value.toFixed(1)} ${unit}`;
+
+    if (safeValue >= 1e15) {
+      return `${(safeValue / 1e15).toFixed(2)} PB`;
+    }
+
+    if (safeValue >= 1e12) {
+      return `${(safeValue / 1e12).toFixed(2)} TB`;
+    }
+
+    if (safeValue >= 1e9) {
+      return `${(safeValue / 1e9).toFixed(2)} MB`;
+    }
+
+    if (safeValue >= 1e6) {
+      return `${(safeValue / 1e6).toFixed(2)} KB`;
+    }
+
+    if (safeValue >= 1e3) {
+      return `${(safeValue / 1e3).toFixed(1)} B`;
+    }
+
+    return `${Math.floor(safeValue)} mB`;
   }
 
   /**
@@ -254,8 +272,7 @@ export class FluidStorage {
   static getFluidFromText(input) {
     const cleaned = input.replace(/§./g, "").trim();
 
-    // Match without "Stored"
-    const match = cleaned.match(/(\w+):\s*([\d.]+)\s*(mB|kB|MB|B)/);
+    const match = cleaned.match(/([^:]+):\s*([\d.]+)\s*(mB|B|kB|MB|GB|TB|PB|EB)/i);
     if (!match) return { type: "empty", amount: 0 };
 
     const [, rawType, rawValue, unit] = match;
@@ -263,12 +280,24 @@ export class FluidStorage {
     const multipliers = {
       mB: 1,
       B: 1000,
-      kB: 1000,
-      MB: 1_000_000,
+      kB: 1_000_000,
+      MB: 1_000_000_000,
+      GB: 1_000_000_000_000,
+      TB: 1_000_000_000_000_000,
+      PB: 1_000_000_000_000_000_000,
+      EB: 1_000_000_000_000_000_000_000,
     };
 
-    const amount = parseFloat(rawValue) * (multipliers[unit] ?? 1);
-    const type = rawType.toLowerCase();
+    let normalizedUnit = unit;
+    if (/^mb$/i.test(unit)) {
+      normalizedUnit = "mB";
+    } else if (/^kb$/i.test(unit)) {
+      normalizedUnit = "kB";
+    } else {
+      normalizedUnit = unit.toUpperCase();
+    }
+    const amount = parseFloat(rawValue) * (multipliers[normalizedUnit] ?? 1);
+    const type = rawType.trim().toLowerCase().replace(/\s+/g, "_");
 
     return { type, amount };
   }

--- a/BP/scripts/DoriosCore/machinery/fluidStorage.js
+++ b/BP/scripts/DoriosCore/machinery/fluidStorage.js
@@ -234,17 +234,21 @@ export class FluidStorage {
   static formatFluid(value) {
     const safeValue = Math.max(0, Number(value) || 0);
 
-    if (safeValue >= 1e18) {
-      return `${(safeValue / 1e18).toFixed(2)} EB`;
+    if (safeValue >= 1e21) {
+      return `${(safeValue / 1e21).toFixed(2)} EB`;
     } // ExaBucket (EB) for extremely large values
 
-    if (safeValue >= 1e15) {
-      return `${(safeValue / 1e15).toFixed(2)} PB`;
+    if (safeValue >= 1e18) {
+      return `${(safeValue / 1e18).toFixed(2)} PB`;
     } // PetaBucket (PB) for very large values
 
-    if (safeValue >= 1e12) {
-      return `${(safeValue / 1e12).toFixed(2)} TB`;
+    if (safeValue >= 1e15) {
+      return `${(safeValue / 1e15).toFixed(2)} TB`;
     } // TeraBucket (TB) for large values
+
+    if (safeValue >= 1e12) {
+      return `${(safeValue / 1e12).toFixed(2)} GB`;
+    } // GigaBucket (GB) for large values
 
     if (safeValue >= 1e9) {
       return `${(safeValue / 1e9).toFixed(2)} MB`;

--- a/BP/scripts/DoriosCore/machinery/fluidStorage.js
+++ b/BP/scripts/DoriosCore/machinery/fluidStorage.js
@@ -235,31 +235,24 @@ export class FluidStorage {
     const safeValue = Math.max(0, Number(value) || 0);
 
     if (safeValue >= 1e18) {
-      return `${(safeValue / 1e18).toFixed(2)} EB`;
-    }
+      return `${(safeValue / 1e18).toFixed(2)} EB`; } // ExaBucket (EB) for extremely large values
 
     if (safeValue >= 1e15) {
-      return `${(safeValue / 1e15).toFixed(2)} PB`;
-    }
+      return `${(safeValue / 1e15).toFixed(2)} PB`; } // PetaBucket (PB) for very large values
 
     if (safeValue >= 1e12) {
-      return `${(safeValue / 1e12).toFixed(2)} TB`;
-    }
+      return `${(safeValue / 1e12).toFixed(2)} TB`; } // TeraBucket (TB) for large values
 
     if (safeValue >= 1e9) {
-      return `${(safeValue / 1e9).toFixed(2)} MB`;
-    }
+      return `${(safeValue / 1e9).toFixed(2)} MB`; } // MegaBucket (MB) for large values
 
     if (safeValue >= 1e6) {
-      return `${(safeValue / 1e6).toFixed(2)} KB`;
-    }
+      return `${(safeValue / 1e6).toFixed(2)} KB`; } // KiloBucket (KB) for medium values
 
     if (safeValue >= 1e3) {
-      return `${(safeValue / 1e3).toFixed(1)} B`;
-    }
+      return `${(safeValue / 1e3).toFixed(1)} B`; } // Bucket (B) for small values
 
-    return `${Math.floor(safeValue)} mB`;
-  }
+    return `${Math.floor(safeValue)} mB`; } // Milibucket (mB) for very small values
 
   /**
    * Extracts the fluid type and amount from a formatted text like:

--- a/BP/scripts/DoriosCore/utils/entity.js
+++ b/BP/scripts/DoriosCore/utils/entity.js
@@ -51,6 +51,67 @@ export function tryGetEntityFromBlock(block) {
   return block.dimension.getEntitiesAtBlockLocation(block.location)[0];
 }
 
+/**
+ * Attempts to resolve the block currently represented by a machine entity.
+ *
+ * Machine helper entities are spawned with a small offset, so the lookup uses
+ * floored coordinates to reach the owning block position.
+ *
+ * @param {import("@minecraft/server").Entity} entity The helper entity to inspect.
+ * @returns {import("@minecraft/server").Block | undefined} The block under the entity, if available.
+ */
+export function tryGetBlockFromEntity(entity) {
+  if (!entity?.dimension || !entity.location) {
+    return undefined;
+  }
+
+  return entity.dimension.getBlock({
+    x: Math.floor(entity.location.x),
+    y: Math.floor(entity.location.y),
+    z: Math.floor(entity.location.z),
+  });
+}
+
+/**
+ * Returns the block type id represented by a machine helper entity.
+ *
+ * Preference order:
+ * 1. Current block under the entity (keeps renamed/swapped machines accurate)
+ * 2. Persisted dynamic property written at spawn time
+ *
+ * @param {import("@minecraft/server").Entity} entity The helper entity to inspect.
+ * @returns {string | undefined} Represented block type id.
+ */
+export function getRepresentedBlockId(entity) {
+  const block = tryGetBlockFromEntity(entity);
+  if (typeof block?.typeId === "string" && block.typeId.length > 0 && block.typeId !== "minecraft:air") {
+    return block.typeId;
+  }
+
+  try {
+    const storedBlockId = entity?.getDynamicProperty?.(Constants.MACHINE_BLOCK_ID_PROPERTY_ID);
+    if (typeof storedBlockId === "string" && storedBlockId.trim().length > 0) {
+      return storedBlockId.trim();
+    }
+  } catch {
+    // Ignore dynamic property access failures.
+  }
+
+  return undefined;
+}
+
+function persistRepresentedBlockId(entity, blockId) {
+  if (!entity || typeof blockId !== "string" || blockId.length === 0) {
+    return;
+  }
+
+  try {
+    entity.setDynamicProperty(Constants.MACHINE_BLOCK_ID_PROPERTY_ID, blockId);
+  } catch {
+    // Ignore environments where the property is not registered yet.
+  }
+}
+
 const configExample = {
   entity: {
     identifier: "utilitycraft:machine",
@@ -103,6 +164,7 @@ export function spawnEntity(block, config) {
 
   const name = entityData.name ?? block.typeId.split(":")[1];
   entity.nameTag = `entity.utilitycraft:${name}.name`;
+  persistRepresentedBlockId(entity, block.typeId);
 
   // Normalize slot config independently
   const inputRange =

--- a/BP/scripts/insight_injectors.js
+++ b/BP/scripts/insight_injectors.js
@@ -7,9 +7,9 @@ const MAX_REGISTRATION_ATTEMPTS = 180;
 const INSIGHT_PROVIDER_NAME = "UtilityCraft";
 const INSIGHT_CUSTOM_COMPONENT_KEYS = Object.freeze([
     "customEnergyInfo",
+    "customFluidInfo",
     "customRotationInfo",
     "customMachineProgress",
-    "customonInfo",
     "customCobblestoneCount",
     "customVariantPreview"
 ]);
@@ -78,6 +78,23 @@ function formatFluid(value) {
 function capitalize(str) {
     if (!str) return str;
     return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function resolveInsightComponentKeys(api, preferredKeys) {
+    const keys = Array.isArray(preferredKeys)
+        ? preferredKeys.filter((key) => typeof key === "string" && key.trim().length > 0)
+        : [];
+
+    if (!api || typeof api.getSupportedComponentKeys !== "function") {
+        return keys;
+    }
+
+    try {
+        const supportedKeys = new Set(api.getSupportedComponentKeys());
+        return keys.filter((key) => supportedKeys.has(key));
+    } catch {
+        return keys;
+    }
 }
 
 function getObjectiveScoreFromCandidates(scoreboardIdentity, objectiveIds) {
@@ -165,7 +182,7 @@ function getEnergyLine(context) {
             return `Energy: ${formatEnergy(scoreboardEnergy.stored)} / ${formatEnergy(scoreboardEnergy.cap)}${formatPercent(scoreboardEnergy.stored, scoreboardEnergy.cap)}`;
         }
 
-        return `Energy: ${formatEnergy(scoreboardEnergyStorage.stored)}`;
+        return `Energy: ${formatEnergy(scoreboardEnergy.stored)}`;
     }
 }
 
@@ -367,9 +384,11 @@ function tryRegisterInjectors() {
         return false;
     }
 
+    const componentKeys = resolveInsightComponentKeys(api, INSIGHT_CUSTOM_COMPONENT_KEYS);
+
     api.registerBlockFieldInjector(collectUtilityCraftBlockFields, {
         provider: INSIGHT_PROVIDER_NAME,
-        components: INSIGHT_CUSTOM_COMPONENT_KEYS
+        components: componentKeys
     });
 
     // State merge: combine E0 (units) + E1 (tens) into a single "Cobblestone" row

--- a/BP/scripts/insight_injectors.js
+++ b/BP/scripts/insight_injectors.js
@@ -48,6 +48,19 @@ function safeGetMachineEntity(block) {
     }
 }
 
+function isUtilityCraftTypeId(typeId) {
+    return typeof typeId === "string"
+        && typeId.trim().toLowerCase().startsWith("utilitycraft:");
+}
+
+function resolveMachineEntity(context) {
+    if (context?.linkedEntity) {
+        return context.linkedEntity;
+    }
+
+    return safeGetMachineEntity(context?.block);
+}
+
 function formatEnergy(value) {
     try {
         if (typeof EnergyStorage?.formatEnergyToText === "function") {
@@ -153,11 +166,19 @@ function getEnergyLine(context) {
         return undefined;
     }
 
-    if (!context.block?.hasTag?.("dorios:energy")) {
+    const blockTypeId = String(context?.block?.typeId || "");
+    if (!isUtilityCraftTypeId(blockTypeId)) {
         return undefined;
     }
 
-    const machineEntity = safeGetMachineEntity(context.block);
+    const hasEnergyTag = context.block?.hasTag?.("dorios:energy") === true;
+    const hasUtilityCraftBlock = isUtilityCraftTypeId(blockTypeId);
+
+    if (!hasEnergyTag && !hasUtilityCraftBlock) {
+        return undefined;
+    }
+
+    const machineEntity = resolveMachineEntity(context);
     if (!machineEntity) {
         return undefined;
     }
@@ -340,31 +361,40 @@ function getVariantLine(context, states) {
 // ---------------------------------------------------------------------------
 
 function collectUtilityCraftBlockFields(context) {
-    if (!context?.playerSettings?.showCustomFields || !context.block) {
+    if (!context?.playerSettings?.showCustomFields || !context?.block) {
         return undefined;
     }
 
-    const states = safeGetBlockStates(context.block);
-    const machineEntity = safeGetMachineEntity(context.block);
+    if (!isUtilityCraftTypeId(context.block.typeId)) {
+        return undefined;
+    }
+
+    const resolvedContext = {
+        ...context,
+        machineEntity: resolveMachineEntity(context)
+    };
+
+    const states = safeGetBlockStates(resolvedContext.block);
+    const machineEntity = resolvedContext.machineEntity;
 
     const lines = [];
 
-    const energyLine = getEnergyLine(context);
+    const energyLine = getEnergyLine(resolvedContext);
     if (energyLine) lines.push(energyLine);
 
-    const fluidLines = getFluidLines(context, machineEntity);
+    const fluidLines = getFluidLines(resolvedContext, machineEntity);
     for (const fl of fluidLines) lines.push(fl);
 
-    const rotationLine = getRotationLine(context, states);
+    const rotationLine = getRotationLine(resolvedContext, states);
     if (rotationLine) lines.push(rotationLine);
 
-    const progressLine = getMachineProgressLine(context, machineEntity);
+    const progressLine = getMachineProgressLine(resolvedContext, machineEntity);
     if (progressLine) lines.push(progressLine);
 
-    const cobbleLine = getCobblestoneCountLine(context, states);
+    const cobbleLine = getCobblestoneCountLine(resolvedContext, states);
     if (cobbleLine) lines.push(cobbleLine);
 
-    const variantLine = getVariantLine(context, states);
+    const variantLine = getVariantLine(resolvedContext, states);
     if (variantLine) lines.push(variantLine);
 
     return lines.length ? lines : undefined;


### PR DESCRIPTION
## Summary
Improve the machine helper data used by Insight so machine overlays can resolve the correct block context more reliably.

## What changed
- persist the represented block id on machine helper entities at spawn time
- normalize energy and fluid text formatting/parsing for plain values and large unit suffixes
- register only Insight component keys that the active API reports as supported
- fix the fallback energy line used by the injector output

## Validation
- confirmed the project compiled successfully through the running Dash watch task